### PR TITLE
introduce betssm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@ happening-docker-credential-helper.rb @superbet-group/sports-infra
 Casks/teleport-cli.rb @superbet-group/sports-infra
 lola.rb @perix4
 riskctl.rb @superbet-group/risk
+betssm.rb @superbet-group/betler

--- a/betssm.rb
+++ b/betssm.rb
@@ -1,0 +1,12 @@
+require_relative "custom_download_strategy"
+cask "betssm" do
+  version "5"
+  sha256 "b65a4d8a08a4a045bfae020e0205fb8167927dec999a3b9e4b00b5ed33c15a79"
+
+  url "https://raw.githubusercontent.com/superbet-group/betler.infra.betssm/refs/tags/#{version}/betssm", using: GitHubPrivateRepositoryFileDownloadStrategy
+  name "betssm"
+  desc "Betler CLI Tool for Interacting with Infra"
+  homepage "https://github.com/superbet-group/betler.infra.betssm"
+
+  binary "#{staged_path}/betler.infra.betssm", target: "/usr/local/bin/betssm"
+end

--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -47,7 +47,7 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
     # Test access to the repository
     GitHub.repository(@owner, @repo)
   rescue GitHub::API::HTTPNotFoundError
-    # We switched to GitHub::API::HTTPNotFoundError, 
+    # We switched to GitHub::API::HTTPNotFoundError,
     # because we can now handle bad credentials messages
     message = <<~EOS
       HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
@@ -66,7 +66,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
   def initialize(url, name, version, **meta)
     super
   end
-  
+
   def resolve_url_basename_time_file_size(url, timeout: nil)
     [download_url, "", Time.now, 0, false]
   end
@@ -108,5 +108,69 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
     #release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
     #GitHub::API.open_rest(release_url)
     GitHub.get_release(@owner, @repo, @tag)
+  end
+end
+
+# GitHubPrivateRepositoryFileDownloadStrategy downloads specific files from GitHub
+# repos. To use it, add
+# `:using => GitHubPrivateRepositoryFileDownloadStrategy` to the URL section of
+# your formula. This download strategy uses GitHub access tokens (in the
+# environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
+class GitHubPrivateRepositoryFileDownloadStrategy < CurlDownloadStrategy
+  require "utils/formatter"
+  require "utils/github"
+
+  def initialize(url, name, version, **meta)
+    super
+    parse_url_pattern
+    set_github_token
+  end
+
+  def parse_url_pattern
+    unless match = url.match(%r{https://raw.githubusercontent.com/([^/]+)\/([^/]+)/refs/tags/([^/]+)/(\S+)})
+      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Repository."
+    end
+
+    _, @owner, @repo, @tag, @filename = *match
+  end
+  def download_url
+    "https://oauth2:#{@github_token}@api.github.com/repos/#{@owner}/#{@repo}/contents/#{@filename}?ref=#{@tag}"
+  end
+
+  private
+
+  #Downloading a file from the API returns it in a json encoded file with field 'content'
+  # which has the content of the field base64 encoded
+  def _fetch(url:, resolved_url:, timeout:)
+    curl_download download_url, to: temporary_path
+    raw = File.read(temporary_path)
+    json = JSON.parse(raw)
+    field = json['content']
+    data = Base64.decode64(field)
+    File.open(temporary_path, 'w') do |file|
+        file.write(data)
+    end
+  end
+
+  def set_github_token
+    @github_token = ENV["HOMEBREW_GITHUB_API_TOKEN"]
+    unless @github_token
+      raise CurlDownloadStrategyError, "Environmental variable HOMEBREW_GITHUB_API_TOKEN is required."
+    end
+
+    validate_github_repository_access!
+  end
+
+  def validate_github_repository_access!
+    # Test access to the repository
+    GitHub.repository(@owner, @repo)
+  rescue GitHub::API::HTTPNotFoundError
+    # We switched to GitHub::API::HTTPNotFoundError,
+    # because we can now handle bad credentials messages
+    message = <<~EOS
+      HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
+      This token may not have permission to access the repository or the url of formula may be incorrect.
+    EOS
+    raise CurlDownloadStrategyError, message
   end
 end


### PR DESCRIPTION
betssm is a script which betler devs use regularly (required part of onboarding).
https://github.com/superbet-group/betler.infra.betssm
I'd like to add it here as the standard repo of tooling in happening.

betssm is a simple 1 line script in its repo so no need to create packages and release pipelines.
To make that work however I had to add a new download strategy which is sufficiently generic.
It pulls down any tagged version of a file.

Unsure what the process is for getting this approved so happy to update.