### PR TITLE
fix: replace define_method with preflight block [SPRI-1033]

### DIFF
--- a/Casks/teleport-cli.rb
+++ b/Casks/teleport-cli.rb
@@ -15,7 +15,7 @@ cask "teleport-cli" do
 
   pkg "teleport-ent-#{version}.pkg"
 
-  define_method(:install) do
+  preflight do
     conflicting_packages = []
     conflicting_casks = []
     conflicting_formulas = []
@@ -49,9 +49,6 @@ cask "teleport-cli" do
 
       odie error_message
     end
-
-    # Proceed with normal installation
-    super
   end
 
   def caveats


### PR DESCRIPTION
# fix: replace define_method with preflight block [SPRI-1033]

## Problem

After implementing the previous fix for deprecated `conflicts_with`, the formula started throwing a new error:

```
Error: Unexpected method 'define_method' called on Cask teleport-cli.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
```

The issue was that `define_method` is not supported in Homebrew's cask DSL. While it works for regular Ruby classes, Homebrew casks have their own specific DSL that doesn't allow dynamic method definitions.

## Root Cause

Homebrew casks use a restricted DSL that only allows specific predefined methods and blocks. Custom method definitions using `define_method` are not permitted and cause the cask to fail validation and installation.

## Solution

Replaced `define_method(:install)` with a `preflight` block, which is the correct way to run custom logic before cask installation in Homebrew's DSL.

### Changes Made

**Before (incorrect):**
```ruby
define_method(:install) do
  # conflict detection logic
  # ...
  super  # This was also problematic in cask context
end
```

**After (correct):**
```ruby
preflight do
  # same conflict detection logic
  # no need for super in preflight
end
```

## Technical Details

- **`preflight`** is the official Homebrew cask DSL method for running code before installation
- Removed the `super` call which is not needed in preflight context
- All conflict detection logic remains exactly the same
- Error messages and user experience unchanged

## Benefits

✅ **Compliant** with Homebrew cask DSL standards  
✅ **No more "Unexpected method" errors** during brew operations  
✅ **Same functionality** - conflict detection still works identically  
✅ **Proper cask lifecycle** - runs at the correct time during installation  

## Testing

- ✅ Ruby syntax validation passes
- ✅ No more Homebrew DSL violations
- ✅ Conflict detection logic unchanged and functional
- ✅ Error messages display correctly

This fix ensures the cask works properly within Homebrew's supported DSL while maintaining all the conflict detection functionality from the previous implementation.


[SPRI-1033]: https://axilis.atlassian.net/browse/SPRI-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ