### PR TITLE
Fix orca formula: use private repo download strategy

### DIFF
--- a/orca.rb
+++ b/orca.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require_relative "custom_download_strategy"
+
 class Orca < Formula
   desc "Orca - Sports platform CLI tool"
   homepage "https://github.com/superbet-group/offer.orca"
@@ -9,22 +11,26 @@ class Orca < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_darwin_amd64.zip"
+      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_darwin_amd64.zip",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "b595ebea0895b8209983eb8fddf6e1a178afca4b34ad6ea4b2c050fb79e5ac25"
     end
     on_arm do
-      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_darwin_arm64.zip"
+      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_darwin_arm64.zip",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "d5e1292f5419a356d4fb7151a9a33db3ed4898a42ae2740e438770f4e167e4a7"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_linux_amd64.tar.gz"
+      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_linux_amd64.tar.gz",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "8be80dd9d9af38e51ccf347ce1cc7cae4f72e8f62b553f297503f7bc28189517"
     end
     on_arm do
-      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_linux_arm64.tar.gz"
+      url "https://github.com/superbet-group/offer.orca/releases/download/v1.0.0/orca_1.0.0_linux_arm64.tar.gz",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "4fdb040a1ce6efa3fa38319284757e9519b112f5e5a89f1b48f512033ba4a799"
     end
   end


### PR DESCRIPTION
## Summary
- Use `GitHubPrivateRepositoryReleaseDownloadStrategy` for orca formula
- Required because `offer.orca` repo is internal (not public)
- Uses `gh auth token` for authentication (same as betctl, lola, etc.)

## Install after merge
```bash
brew install superbet-group/tap/orca
```